### PR TITLE
Change/add pseudo headers

### DIFF
--- a/lib/HARToPostmanCollectionMapper.js
+++ b/lib/HARToPostmanCollectionMapper.js
@@ -32,7 +32,6 @@ const DEFAULT_COLLECTION_NAME = 'Generated from HAR',
   {
     groupEntriesByOption
   } = require('./utils/groupingHelper'),
-  pseudoHeaders = [':method', ':scheme', ':authority', ':path'],
   COOKIE_HEADER_KEY = 'Cookie',
   SET_COOKIE_HEADER_KEY = 'Set-Cookie';
 
@@ -177,17 +176,6 @@ function getBody(harRequest, options) {
 }
 
 /**
- * Exclude the pseudo header
- * @param {Array} header the header to check if we are going to exclude
- * @param {string} headerName name of the header to exclude
- * @returns {Array} filtered headers
- */
-function excludePseudoHeader(header) {
-  return !pseudoHeaders.includes(header.name.toLowerCase());
-}
-
-
-/**
  * Exclude the provided header from the list
  * @param {Array} headersList array of headers
  * @param {string} headerName name of the header to exclude
@@ -235,8 +223,7 @@ function filterCookiesFromHeader(headersList, options, cookieHeaderKey) {
  * @returns {Array} postman's headers
  */
 function getItemRequestHeaders(harRequestHeaders, options) {
-  let filteredHeaders = filterCookiesFromHeader(harRequestHeaders, options,
-      COOKIE_HEADER_KEY).filter(excludePseudoHeader),
+  let filteredHeaders = filterCookiesFromHeader(harRequestHeaders, options, COOKIE_HEADER_KEY),
     headersFromHARHeaders = filteredHeaders.map((header) => {
       return { key: header.name, value: header.value };
     });
@@ -250,8 +237,7 @@ function getItemRequestHeaders(harRequestHeaders, options) {
  * @returns {Array} postman's headers
  */
 function getItemResponseHeaders(harResponseHeaders, options) {
-  return filterCookiesFromHeader(harResponseHeaders, options,
-    SET_COOKIE_HEADER_KEY).filter(excludePseudoHeader).map((header) => {
+  return filterCookiesFromHeader(harResponseHeaders, options, SET_COOKIE_HEADER_KEY).map((header) => {
     return { key: header.name, value: header.value };
   });
 }

--- a/test/system/convertion.test.js
+++ b/test/system/convertion.test.js
@@ -76,7 +76,7 @@ describe('E2E Flows convert a HAR file into a PM Collection', function () {
       {},
       (error, result) => {
         expect(error).to.be.null;
-        expect(result.output[0].data.item[0].item[9].request.header.length).to.eql(12);
+        expect(result.output[0].data.item[0].item[9].request.header.length).to.eql(16);
         expect(result.output[0].data.item[0].item[9].response[0].cookie).to.be.empty;
       }
     );
@@ -89,7 +89,7 @@ describe('E2E Flows convert a HAR file into a PM Collection', function () {
       { includeCookies: true },
       (error, result) => {
         expect(error).to.be.null;
-        expect(result.output[0].data.item[0].item[9].request.header.length).to.eql(13);
+        expect(result.output[0].data.item[0].item[9].request.header.length).to.eql(17);
         expect(result.output[0].data.item[0].item[9].response[0].cookie).not.to.be.empty;
       }
     );

--- a/test/unit/HARToPostmanCollectionMapper.test.js
+++ b/test/unit/HARToPostmanCollectionMapper.test.js
@@ -321,10 +321,9 @@ describe('HARToPostmanCollectionMapper getItemRequestHeaders', function () {
       result = getItemRequestHeaders(harRequestHeaders);
     expect(result).to.not.be.undefined;
     expect(Array.isArray(result)).to.be.true;
-    expect(result.length).to.equal(2);
     expect(result[0].key).to.equal('Host');
     expect(result[0].value).to.equal('localhost:3000');
-    expect(result.length).to.equal(2);
+    expect(result.length).to.equal(6);
   });
 
 });


### PR DESCRIPTION
Remove code that filters the pseudo headers 

"Regarding 1, from a converter perspective, let's still include them to avoid data loss from HAR in the collection schema. How the Postman app treats them can be a separate concern"