### PR TITLE
Disable pseudo headers in the request to unblock execution

### DIFF
--- a/lib/HARToPostmanCollectionMapper.js
+++ b/lib/HARToPostmanCollectionMapper.js
@@ -32,9 +32,20 @@ const DEFAULT_COLLECTION_NAME = 'Generated from HAR',
   {
     groupEntriesByOption
   } = require('./utils/groupingHelper'),
+
+  PSEUDO_HEADERS = [':method', ':scheme', ':authority', ':path'],
   COOKIE_HEADER_KEY = 'Cookie',
   SET_COOKIE_HEADER_KEY = 'Set-Cookie';
 
+/**
+ * Decides whether to disable a particular header or not
+ * @param {Object} header Header object
+ * @param {String} headerName Header name
+ * @returns {Boolean} True if the header must be disabled
+ */
+function shouldDisableHeader(header) {
+  return PSEUDO_HEADERS.includes(header.name.toLowerCase());
+}
 
 /**
  * Gets the different urls and its index to create variables for them
@@ -225,7 +236,13 @@ function filterCookiesFromHeader(headersList, options, cookieHeaderKey) {
 function getItemRequestHeaders(harRequestHeaders, options) {
   let filteredHeaders = filterCookiesFromHeader(harRequestHeaders, options, COOKIE_HEADER_KEY),
     headersFromHARHeaders = filteredHeaders.map((header) => {
-      return { key: header.name, value: header.value };
+      const postmanHeader = { key: header.name, value: header.value };
+
+      if (shouldDisableHeader(header)) {
+        postmanHeader.disabled = true;
+      }
+
+      return postmanHeader;
     });
   return headersFromHARHeaders;
 }

--- a/test/unit/HARToPostmanCollectionMapper.test.js
+++ b/test/unit/HARToPostmanCollectionMapper.test.js
@@ -291,7 +291,7 @@ describe('HARToPostmanCollectionMapper getItemRequestHeaders', function () {
     expect(result.length).to.equal(0);
   });
 
-  it('Should exclude pseudo headers from list', function () {
+  it('Should disable pseudo headers from list', function () {
     const harRequestHeaders = [
         {
           'name': 'Host',
@@ -324,8 +324,13 @@ describe('HARToPostmanCollectionMapper getItemRequestHeaders', function () {
     expect(result[0].key).to.equal('Host');
     expect(result[0].value).to.equal('localhost:3000');
     expect(result.length).to.equal(6);
-  });
 
+    result.forEach((header) => {
+      if ([':method', ':scheme', ':authority', ':path'].includes(header.name)) {
+        expect(header.disabled).to.equal(true);
+      }
+    });
+  });
 });
 
 


### PR DESCRIPTION
Since Postman does not have HTTP/2 protocol support yet, these headers are treated as invalid in the app. Disabling pseudo headers ensures that both the information is not lost and also no disruption occurs in the collection execution workflow