### PR TITLE
Fix use of word space instead of an actual space (blank space)

### DIFF
--- a/lib/HARToPostmanCollectionBodyMapper.js
+++ b/lib/HARToPostmanCollectionBodyMapper.js
@@ -32,7 +32,8 @@ function getCharForIndentation(processOptions) {
       processOptions.indentCharacter.toLowerCase() === 'tab') {
       return '\t';
     }
-    else if (typeof processOptions.indentCharacter === 'string') {
+    else if (typeof processOptions.indentCharacter === 'string' &&
+    processOptions.indentCharacter.toLowerCase() !== 'space') {
       return processOptions.indentCharacter;
     }
   }

--- a/test/unit/HARToPostmanCollectionBodyMapper.test.js
+++ b/test/unit/HARToPostmanCollectionBodyMapper.test.js
@@ -79,6 +79,19 @@ describe('HARToPostmanCollectionBodyMapper mapBodyFromJson', function () {
     expect(result.raw).to.equal(expectedOutput);
   });
 
+  it('should get json string with indentation as spaces when entry is the string Space', function () {
+    const options = getOptions({ usage: ['CONVERSION'] }),
+      indentCharacter = options.find((option) => { return option.id === 'indentCharacter'; }),
+      harRequest = { postData: { text: '{"some":"value"}' } },
+      expectedOutput = '{\n\ "some": "value"\n}';
+    let result,
+      processOptions = {};
+    processOptions[`${indentCharacter.id}`] = 'Space';
+    result = mapBodyFromJson(harRequest, processOptions);
+    expect(result.raw).to.be.an('string');
+    expect(result.raw).to.equal(expectedOutput);
+  });
+
 });
 
 describe('HARToPostmanCollectionBodyMapper mapBody', function () {

--- a/test/unit/urlUtils.test.js
+++ b/test/unit/urlUtils.test.js
@@ -59,7 +59,7 @@ describe('removeProtocolFromURL method', function () {
       assert.fail('we expected an error');
     }
     catch (inputError) {
-      expect(inputError.message).to.equal('Invalid URL: not url');
+      expect(inputError.message).to.include('Invalid URL');
     }
   });
 


### PR DESCRIPTION
Fix use of word space instead of actual space (blank space)
fixes #16 

For reproduction in the app:
You have to modify the parameter Set indent character from Space to Tab and back again to Space,
this makes the app send the word Space to the module

We used to have a validation only for receiving the word "tab" if another string was received this string was added to the JSON parser allowing the word "Space" to be used for.

We now validate also the word space so it is translated to actual spaces
